### PR TITLE
Update fallback PATH and MANPATH additions not to rely on the X11 conven...

### DIFF
--- a/init.csh.in
+++ b/init.csh.in
@@ -73,13 +73,28 @@ else
 endif
 
 # Add X11 paths (but only if the directories are readable)
-# Don't add /usr/X11R6/bin if it or another X11 executable path is already
-# available
-if ( -r /usr/X11R6/bin && "$PATH" !~ *X11*/bin ) then
-    append_path PATH /usr/X11R6/bin
+# Don't add them if an X11 path is already available.
+if ( "$PATH" !~ *X11*/bin ) then
+	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
+	# We support /opt/X11 for 10.8 and later
+	if ( -r /opt/X11/bin && $osMajorVersion > 11 ) then
+    	append_path PATH /opt/X11/bin
+	else if ( -r /usr/X11/bin ) then
+    	append_path PATH /usr/X11/bin
+	else if ( -r /usr/X11R6/bin ) then
+    	append_path PATH /usr/X11R6/bin
+	endif
 endif
-if ( -r /usr/X11R6/man ) then
-    append_path MANPATH /usr/X11R6/man
+if ( "$PATH" !~ *X11*/man ) then
+	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
+	# We support /opt/X11 for 10.8 and later
+	if ( -r /opt/X11/share/man && $osMajorVersion > 11 ) then
+    	append_path PATH /opt/X11/share/man
+	else if ( -r /usr/X11/share/man ) then
+    	append_path PATH /usr/X11/share/man
+	else if ( -r /usr/X11R6/share/man ) then
+    	append_path PATH /usr/X11R6/share/man
+	endif
 endif
 
 # On Mac OS X 10.4.{x|x<3} there is a dyld bug (rdar://problem/4139432)

--- a/init.sh.in
+++ b/init.sh.in
@@ -90,7 +90,9 @@ export PERL5LIB
 
 # Add X11 paths (but only if the directories are readable)
 # Don't add them if an X11 path is already available.
-if [ "`echo $PATH | grep 'X11.*/bin'`x" = "x" ]; then
+# Unfortunately, some Bourne-type shells don't handle using =~ to test strings,
+# which would be more convenient.  Hopefully this will be sufficiently back-compatible.
+if [ ! -z "${PATH##*'X11'*bin}" ]; then
 	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
 	# We support /opt/X11 for 10.8 and later
 	if [ -r /opt/X11/bin ] &&  [ $osMajorVer -gt 11 ]; then
@@ -104,7 +106,7 @@ if [ "`echo $PATH | grep 'X11.*/bin'`x" = "x" ]; then
    		export PATH
 	fi
 fi
-if [ "`echo $PATH | grep 'X11.*/man'`x" = "x" ]; then
+if [ ! -z "${PATH##*'X11'*man}" ]; then
 	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
 	# We support /opt/X11 for 10.8 and later
 	if [ -r /opt/X11/share/man ] &&  [ $osMajorVer -gt 11 ]; then

--- a/init.sh.in
+++ b/init.sh.in
@@ -89,17 +89,35 @@ fi
 export PERL5LIB
 
 # Add X11 paths (but only if the directories are readable)
-# Don't add /usr/X11R6/bin if it or another X11 executable path is already
-# available
-if [ -r /usr/X11R6/bin ] &&  [ "`echo $PATH | grep 'X11.*/bin'`x" = "x" ]; then
-    append_path PATH /usr/X11R6/bin
-    export PATH
+# Don't add them if an X11 path is already available.
+if [ "`echo $PATH | grep 'X11.*/bin'`x" = "x" ]; then
+	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
+	# We support /opt/X11 for 10.8 and later
+	if [ -r /opt/X11/bin ] &&  [ $osMajorVer -gt 11 ]; then
+    	append_path PATH /opt/X11/bin
+   		export PATH
+	elif [ -r /usr/X11/bin ]; then
+    	append_path PATH /usr/X11/bin
+   		export PATH
+	elif [ -r /usr/X11R6/bin ]; then
+    	append_path PATH /usr/X11R6/bin
+   		export PATH
+	fi
 fi
-if [ -r /usr/X11R6/man ]; then
-    append_path MANPATH /usr/X11R6/man
-    export MANPATH
+if [ "`echo $PATH | grep 'X11.*/man'`x" = "x" ]; then
+	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
+	# We support /opt/X11 for 10.8 and later
+	if [ -r /opt/X11/share/man ] &&  [ $osMajorVer -gt 11 ]; then
+    	append_path PATH /opt/X11/share/man
+   		export PATH
+	elif [ -r /usr/X11/share/man ]; then
+    	append_path MANPATH /usr/X11/share/man
+    	export MANPATH
+	elif [ -r /usr/X11R6/share/man ]; then
+    	append_path MANPATH /usr/X11R6/share/man
+    	export MANPATH
+	fi
 fi
-
 # On Mac OS X 10.4.{x|x<3} there is a dyld bug (rdar://problem/4139432)
 # where a library will not load if a library with a matching basename
 # is already loaded from one of the system paths,

--- a/init.sh.in
+++ b/init.sh.in
@@ -92,7 +92,7 @@ export PERL5LIB
 # Don't add them if an X11 path is already available.
 # Unfortunately, some Bourne-type shells don't handle using =~ to test strings,
 # which would be more convenient.  Hopefully this will be sufficiently back-compatible.
-if [ ! -z "${PATH##*'X11'*bin}" ]; then
+if [ ! -z "${PATH##*X11*bin}" ]; then
 	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
 	# We support /opt/X11 for 10.8 and later
 	if [ -r /opt/X11/bin ] &&  [ $osMajorVer -gt 11 ]; then
@@ -106,7 +106,7 @@ if [ ! -z "${PATH##*'X11'*bin}" ]; then
    		export PATH
 	fi
 fi
-if [ ! -z "${PATH##*'X11'*man}" ]; then
+if [ ! -z "${MANPATH##*X11*man}" ]; then
 	# Add appropriate paths.  We'll use the real path rather than convenience symlinks  
 	# We support /opt/X11 for 10.8 and later
 	if [ -r /opt/X11/share/man ] &&  [ $osMajorVer -gt 11 ]; then


### PR DESCRIPTION
...ience symlinks.

Just trying to clean things up a bit.  It's best not to have /usr/X11R6/bin in the PATH if there's no /usr/X11R6. 
